### PR TITLE
host_os OSX/Linux spec fix

### DIFF
--- a/spec/lib/rspec/hive/configuration_spec.rb
+++ b/spec/lib/rspec/hive/configuration_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe RSpec::Hive::Configuration do
 
   context 'when no configuration file is provided' do
     let(:expected_port) { 10000 }
+    let(:original_host_os) { RbConfig::CONFIG['host_os'] }
 
     before { allow(Dir).to receive(:mktmpdir) { mock_tmpdir } }
 
@@ -65,6 +66,8 @@ RSpec.describe RSpec::Hive::Configuration do
         RbConfig::CONFIG['host_os'] = 'mac os'
       end
 
+      after { RbConfig::CONFIG['host_os'] = original_host_os }
+
       include_examples('config')
     end
 
@@ -76,6 +79,8 @@ RSpec.describe RSpec::Hive::Configuration do
       before do
         RbConfig::CONFIG['host_os'] = 'linux'
       end
+
+      after { RbConfig::CONFIG['host_os'] = original_host_os }
 
       include_examples('config')
     end

--- a/spec/lib/rspec/hive/configuration_spec.rb
+++ b/spec/lib/rspec/hive/configuration_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe RSpec::Hive::Configuration do
       include_examples('config')
     end
 
-    context 'where there are some parametres required and optional' do
+    context 'where there are some parameters required and optional' do
       let(:yaml_hash) do
         {
           'hive' =>


### PR DESCRIPTION
Failure were caused by setting `host_os` in specs.