### PR TITLE
Better failure messages

### DIFF
--- a/lib/rspec/hive/matchers.rb
+++ b/lib/rspec/hive/matchers.rb
@@ -2,7 +2,6 @@ require 'rspec/matchers'
 
 RSpec::Matchers.define :match_result_set do |expected|
   match do |actual|
-    return false if expected.size != actual.size
     @diffable_actual = []
     expected.map.with_index do |expected_row, i|
       if expected_row.respond_to?(:each_pair)
@@ -21,7 +20,7 @@ RSpec::Matchers.define :match_result_set do |expected|
       else
         raise ArgumentError, 'Unknown type'
       end
-    end.all?
+    end.all? && expected.size == actual.size
   end
 
   chain :partially do

--- a/lib/rspec/hive/matchers.rb
+++ b/lib/rspec/hive/matchers.rb
@@ -29,8 +29,15 @@ RSpec::Matchers.define :match_result_set do |expected|
   end
 
   failure_message do |actual|
-    "expected #{actual} to match result set #{expected}\n"\
-      "Diff: #{differ.diff_as_object(@diffable_actual, expected)}"
+    "expected #{actual} to match result set #{expected}\n#{diff_message(expected)}"
+  end
+
+  failure_message_when_negated do |actual|
+    "expected #{actual} not to match result set #{expected}, but did\n#{diff_message(expected)}"
+  end
+
+  def diff_message(expected)
+    "Diff: #{differ.diff_as_object(@diffable_actual, expected)}"
   end
 
   def differ

--- a/spec/lib/rspec/hive/matchers_spec.rb
+++ b/spec/lib/rspec/hive/matchers_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe 'match_result_set' do
   let(:full_match_fails) { expect(actual_rows).not_to match_result_set(expected_rows) }
   let(:partial_match_fails) { expect(actual_rows).not_to match_result_set(expected_rows).partially }
 
+  let(:partial_match_raises_error) do
+    expect { partial_match }.to raise_error(ArgumentError, "Can't use partially matcher with Arrays")
+  end
+
   context 'when the expected set has only one row' do
     context 'but the actual set has more rows' do
       let(:actual_rows) { [john, paul] }
@@ -20,6 +24,7 @@ RSpec.describe 'match_result_set' do
         let(:expected_rows) { [john.values] }
 
         specify { full_match_fails }
+        specify { partial_match_raises_error }
       end
 
       context 'when the row is given as a hash' do
@@ -38,24 +43,28 @@ RSpec.describe 'match_result_set' do
           let(:expected_rows) { [john.values << 'yoko'] }
 
           specify { full_match_fails }
+          specify { partial_match_raises_error }
         end
 
         context 'when the actual and expected have are different' do
           let(:expected_rows) { [paul.values] }
 
           specify { full_match_fails }
+          specify { partial_match_raises_error }
         end
 
         context 'when the actual and expected rows are equal' do
           let(:expected_rows) { [john.values] }
 
           specify { full_match }
+          specify { partial_match_raises_error }
         end
 
         context 'when the actual and expected rows are equal with rspec matchers' do
           let(:expected_rows) { [[a_string_matching('John'), a_string_matching(/lennon/i), 40]] }
 
           specify { full_match }
+          specify { partial_match_raises_error }
         end
       end
 

--- a/spec/lib/rspec/hive/matchers_spec.rb
+++ b/spec/lib/rspec/hive/matchers_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'match_result_set' do
         let(:expected_rows) { [john.values] }
 
         specify { full_match_fails }
-        specify { partial_match_fails }
       end
 
       context 'when the row is given as a hash' do


### PR DESCRIPTION
* the diff was not present for negative conditions `expect().not_to match_result_set()`.
* show proper diff if sizes differ

@jekuta @wmiel Please review.