### PR TITLE
Feature/config updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,11 @@ PATH
   remote: .
   specs:
     rspec-hive (0.6.0)
-      colorize (~> 0.7)
+      colorize (~> 0.8.0)
       faker (~> 1.6)
-      rake (>= 10.0, < 12.0)
-      rbhive-u2i (~> 1.0.0)
-      retryable (~> 2.0.3)
+      rake (>= 10.0, < 13.0)
+      rbhive-u2i (~> 1.0)
+      retryable (~> 2.0)
       rspec (~> 3.4)
 
 GEM

--- a/rspec-hive.gemspec
+++ b/rspec-hive.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rake', ['>= 10.0', '< 12.0']
-  spec.add_dependency 'colorize', '~> 0.7'
+  spec.add_dependency 'rake', ['>= 10.0', '< 13.0']
+  spec.add_dependency 'colorize', '~> 0.8.0'
   spec.add_dependency 'faker', '~> 1.6'
-  spec.add_dependency 'retryable', '~> 2.0.3'
+  spec.add_dependency 'retryable', '~> 2.0'
   spec.add_dependency 'rspec', '~> 3.4'
-  spec.add_dependency 'rbhive-u2i', '~> 1.0.0'
+  spec.add_dependency 'rbhive-u2i', '~> 1.0'
 end


### PR DESCRIPTION
Since we release a new gem version to rubygems, it'd be good to update the dependencies.

Is there any particular reason why rake gem was limited as < 12 ?